### PR TITLE
Hot fix border secondary button

### DIFF
--- a/src/main/typescript/wcardinal/ui/theme/dark/d-theme-dark-button-secondary.ts
+++ b/src/main/typescript/wcardinal/ui/theme/dark/d-theme-dark-button-secondary.ts
@@ -29,7 +29,7 @@ export class DThemeDarkButtonSecondary extends DThemeDarkButtonBase {
 	}
 
 	getBorderColor( state: DBaseState ): number | null {
-		if( DBaseStates.isDisabled( state ) || ! DBaseStates.isActive( state )) {
+		if( DBaseStates.isDisabled( state ) ) {
 			return this.COLOR_DISABLED;
 		}
 		return null;


### PR DESCRIPTION
- Remove condition " !DBaseStates.isActive( state ) " to return
DISABLED BORDER COLOR