### PR TITLE
Hot fix chart dark theme color

### DIFF
--- a/src/main/typescript/wcardinal/ui/d-chart-axis-base-options-parser.ts
+++ b/src/main/typescript/wcardinal/ui/d-chart-axis-base-options-parser.ts
@@ -398,7 +398,7 @@ export class DChartAxisBaseOptionParser {
 		options = options || {};
 		return {
 			format: options.format,
-			color: options.color,
+			color: this.toMajorTickTextColor( theme, options.color ),
 			alpha: options.alpha,
 			family: options.family,
 			size: options.size,
@@ -494,6 +494,13 @@ export class DChartAxisBaseOptionParser {
 		return ( options != null ? options : theme.getMajorTickTextDirection() );
 	}
 
+	protected toMajorTickTextColor(
+		theme: DThemeChartAxisBase,
+		options?: number
+	): number {
+		return ( options != null ? options : theme.getMajorTickTextColor() );
+	}
+
 	protected toLabel(
 		theme: DThemeChartAxisBase,
 		options?: DChartAxisBaseOptions
@@ -502,7 +509,7 @@ export class DChartAxisBaseOptionParser {
 		if( label ) {
 			return {
 				value: label.value,
-				color: label.color,
+				color: this.toLabelColor(theme, label.color),
 				alpha: label.alpha,
 				family: label.family,
 				size: label.size,
@@ -597,5 +604,12 @@ export class DChartAxisBaseOptionParser {
 		options?: EShapeTextDirection
 	): EShapeTextDirection {
 		return ( options != null ? options : theme.getLabelDirection() );
+	}
+
+	protected toLabelColor(
+		theme: DThemeChartAxisBase,
+		options?: number
+	): number {
+		return ( options != null ? options : theme.getLabelColor() );
 	}
 }

--- a/src/main/typescript/wcardinal/ui/d-chart-axis-base-options.ts
+++ b/src/main/typescript/wcardinal/ui/d-chart-axis-base-options.ts
@@ -97,6 +97,7 @@ export interface DThemeChartAxisBase {
 	getLabelPaddingHorizontal(): number;
 	getLabelPaddingVertical(): number;
 	getLabelDirection(): EShapeTextDirection;
+	getLabelColor(): number;
 
 	getStyle(): EShapePointsStyle;
 
@@ -117,6 +118,7 @@ export interface DThemeChartAxisBase {
 	getMajorTickTextAlignVertical( position: DChartAxisPosition ): EShapeTextAlignVertical;
 	getMajorTickTextDirection(): EShapeTextDirection;
 	getMajorTickTextFormat(): string;
+	getMajorTickTextColor(): number;
 	getMajorTickTextPaddingHorizontal(): number;
 	getMajorTickTextPaddingVertical(): number;
 	getMajorTickStrokeEnable(): boolean;

--- a/src/main/typescript/wcardinal/ui/shape/e-shape-defaults.ts
+++ b/src/main/typescript/wcardinal/ui/shape/e-shape-defaults.ts
@@ -11,7 +11,7 @@ export class EShapeDefaults {
 	static FILL_COLOR: number = 0xffffff;
 	static FILL_ALPHA: number = 0.5;
 	static STROKE_COLOR: number = 0x4f4f4f;
-	static STROKE_COLOR_DARK: number = 0xdedede;
+	static STROKE_COLOR_DARK: number = 0x4f4f4f;
 	static STROKE_COLOR_LIGHT: number = 0xd0d0d0;
 	static STROKE_ALPHA: number = 1;
 	static STROKE_WIDTH: number = 2;

--- a/src/main/typescript/wcardinal/ui/shape/e-shape-defaults.ts
+++ b/src/main/typescript/wcardinal/ui/shape/e-shape-defaults.ts
@@ -11,7 +11,7 @@ export class EShapeDefaults {
 	static FILL_COLOR: number = 0xffffff;
 	static FILL_ALPHA: number = 0.5;
 	static STROKE_COLOR: number = 0x4f4f4f;
-	static STROKE_COLOR_DARK: number = 0x4f4f4f;
+	static STROKE_COLOR_DARK: number = 0xdedede;
 	static STROKE_COLOR_LIGHT: number = 0xd0d0d0;
 	static STROKE_ALPHA: number = 1;
 	static STROKE_WIDTH: number = 2;

--- a/src/main/typescript/wcardinal/ui/theme/dark/d-theme-dark-chart-axis-base.ts
+++ b/src/main/typescript/wcardinal/ui/theme/dark/d-theme-dark-chart-axis-base.ts
@@ -73,7 +73,7 @@ export class DThemeDarkChartAxisBase implements DThemeChartAxisBase {
 	}
 
 	getStrokeColor(): number {
-		return EShapeDefaults.STROKE_COLOR_DARK;
+		return 0xdedede;
 	}
 
 	getStrokeAlpha(): number {

--- a/src/main/typescript/wcardinal/ui/theme/dark/d-theme-dark-chart-axis-base.ts
+++ b/src/main/typescript/wcardinal/ui/theme/dark/d-theme-dark-chart-axis-base.ts
@@ -60,6 +60,10 @@ export class DThemeDarkChartAxisBase implements DThemeChartAxisBase {
 		return EShapeTextDirection.LEFT_TO_RIGHT;
 	}
 
+	getLabelColor(): number {
+		return this.getStrokeColor();
+	}
+
 	getStyle(): EShapePointsStyle {
 		return EShapePointsStyle.NONE;
 	}
@@ -69,7 +73,7 @@ export class DThemeDarkChartAxisBase implements DThemeChartAxisBase {
 	}
 
 	getStrokeColor(): number {
-		return EShapeDefaults.STROKE_COLOR;
+		return EShapeDefaults.STROKE_COLOR_DARK;
 	}
 
 	getStrokeAlpha(): number {
@@ -136,6 +140,10 @@ export class DThemeDarkChartAxisBase implements DThemeChartAxisBase {
 
 	getMajorTickTextDirection(): EShapeTextDirection {
 		return EShapeTextDirection.LEFT_TO_RIGHT;
+	}
+
+	getMajorTickTextColor(): number {
+		return this.getStrokeColor();
 	}
 
 	getMajorTickTextFormat(): string {

--- a/src/main/typescript/wcardinal/ui/theme/white/d-theme-white-chart-axis-base.ts
+++ b/src/main/typescript/wcardinal/ui/theme/white/d-theme-white-chart-axis-base.ts
@@ -60,6 +60,10 @@ export class DThemeWhiteChartAxisBase implements DThemeChartAxisBase {
 		return EShapeTextDirection.LEFT_TO_RIGHT;
 	}
 
+	getLabelColor(): number {
+		return this.getStrokeColor();
+	}
+
 	getStyle(): EShapePointsStyle {
 		return EShapePointsStyle.NONE;
 	}
@@ -136,6 +140,10 @@ export class DThemeWhiteChartAxisBase implements DThemeChartAxisBase {
 
 	getMajorTickTextDirection(): EShapeTextDirection {
 		return EShapeTextDirection.LEFT_TO_RIGHT;
+	}
+
+	getMajorTickTextColor(): number {
+		return this.getStrokeColor();
 	}
 
 	getMajorTickTextFormat(): string {


### PR DESCRIPTION
- Change Stroke color dark into 0xdedede
- Add MajorTickTextColor and LabelColor to DThemeChartAxisBase
- Get MajorTickTextColor and LabelColor from Options or Theme instead of
only Options
